### PR TITLE
Print more config to stdout

### DIFF
--- a/blogware.py
+++ b/blogware.py
@@ -197,6 +197,11 @@ if __name__ == "__main__":
 
     print('Site name: {}'.format(Config.SITENAME))
     print('Site url: {}'.format(Config.SITEURL))
+    print('Port: {}'.format(Config.PORT))
+    print('Debug: {}'.format(Config.DEBUG))
+    if Config.DEBUG:
+        print('DB URI: {}'.format(Config.DB_URI))
+        print('Secret Key: {}'.format(Config.SECRET_KEY))
 
     if args.create_db:
         print('Setting up the database')


### PR DESCRIPTION
When diagnosing problems with an installation, it is useful to see the actual configuration values used to start the app.

`SECRET_KEY` should not be revealed under normal (production) circumstances, so it is only printed when debug mode has been enabled. `DB_URI` can contain passwords, so it is only printed when debug is enabled as well.