### PR TITLE
Dont list drafts to non logged in users

### DIFF
--- a/blogware.py
+++ b/blogware.py
@@ -225,8 +225,8 @@ def get_post(post_id):
     return render_template('post.html', config=Config, post=post, user=user)
 
 
-@login_required
 @app.route('/edit/<post_id>', methods=['GET', 'POST'])
+@login_required
 def edit_post(post_id):
     post = Post.query.get(post_id)
     if request.method == 'GET':
@@ -246,8 +246,8 @@ def edit_post(post_id):
     return redirect(url_for('get_post', post_id=post_id))
 
 
-@login_required
 @app.route('/new', methods=['GET', 'POST'])
+@login_required
 def create_new():
     if request.method == 'GET':
         post = Post('', '', datetime.now(), True)

--- a/blogware.py
+++ b/blogware.py
@@ -31,7 +31,7 @@ from flask_login import UserMixin, LoginManager, \
     login_user, logout_user, AnonymousUserMixin, current_user, login_required
 from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
-from werkzeug.exceptions import ServiceUnavailable
+from werkzeug.exceptions import ServiceUnavailable, Unauthorized
 import git
 import gfm
 import markdown
@@ -221,6 +221,8 @@ def login():
 def get_post(post_id):
 
     post = Post.query.get(post_id)
+    if post.is_draft and not current_user.is_authenticated:
+        raise Unauthorized()
     user = current_user
     return render_template('post.html', config=Config, post=post, user=user)
 

--- a/blogware.py
+++ b/blogware.py
@@ -187,7 +187,10 @@ def render_gfm(s):
 
 @app.route("/")
 def index():
-    posts = Post.query.order_by(Post.date.desc()).limit(10)
+    query = Post.query
+    if not current_user.is_authenticated:
+        query = query.filter_by(is_draft=False)
+    posts = query.order_by(Post.date.desc()).limit(10)
     return render_template("index.html", posts=posts)
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
     {% for post in posts %}
         <div class="index-post index-post-id-{{post.id}} index-post-index-{{index()}} index-post-{{odd_even()}}">
             <a href="{{ url_for('get_post', post_id=post.id) }}">
-                <h1>{{ post.title }}</h1>
+                <h1>{{ post.title }}{% if post.is_draft%} <small>(Draft)</small>{% endif %}</h1>
             </a>
             <p>{{ post.date.strftime('%Y-%m-%d') }} - izrik</p>
             <hr/>

--- a/templates/post.html
+++ b/templates/post.html
@@ -23,7 +23,7 @@
 
 <div class="container">
     <a href="{{ url_for('get_post', post_id=post.id) }}">
-        <h1 class="post-title">{{ post.title }}</h1>
+        <h1 class="post-title">{{ post.title }}{% if post.is_draft%} <small>(Draft)</small>{% endif %}</h1>
     </a>
     <p class="post-date">{{ post.date.strftime('%Y-%m-%d') }}</p>
     <p class="post-author">Posted by izrik</p>


### PR DESCRIPTION
This PR:
- changes how posts are listed on the front page so that users can't see drafts unless logged in
- prevents users from looking at drafts by crafting a uri
- displays "(Draft)" to indicate drafts
- fixes a bug with `@login_required` placement where users weren't required to log in

Fixes #10 
Fixes #11 