### PR TITLE
Set sitename from db

### DIFF
--- a/blogware.py
+++ b/blogware.py
@@ -170,6 +170,10 @@ class Options(object):
         return Options.get('sitename', Config.SITENAME)
 
     @staticmethod
+    def get_siteurl():
+        return Options.get('siteurl', Config.SITEURL)
+
+    @staticmethod
     def get_revision():
         return __revision__
 

--- a/blogware.py
+++ b/blogware.py
@@ -186,9 +186,6 @@ class Options(object):
 
     cycle = cycle
 
-    Config = Config
-    config = Config
-
 
 @login_manager.user_loader
 def load_user(user_id):

--- a/blogware.py
+++ b/blogware.py
@@ -166,8 +166,8 @@ class Options(object):
         return option.value
 
     @staticmethod
-    def get_title():
-        return Options.get('title', Config.SITENAME)
+    def get_sitename():
+        return Options.get('sitename', Config.SITENAME)
 
     @staticmethod
     def get_revision():

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,7 +26,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>
         {% block title %}
-        {{ Options.config.SITENAME }}
+        {{ Options.get_sitename() }}
         {% endblock title %}
     </title>
     <style>
@@ -46,7 +46,7 @@
     <div class="navbar navbar-default navbar-fixed-top">
         <div class="container">
             <div class="navbar-header">
-                <a class="navbar-brand" href="{{ url_for('index') }}">{{ Options.config.SITENAME }}</a>
+                <a class="navbar-brand" href="{{ url_for('index') }}">{{ Options.get_sitename() }}</a>
             </div>
             <div class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">


### PR DESCRIPTION
This PR changes how the site name and site url are looked up. They are now dynamic, meaning that setting them in the database overrides both env vars and command line options.

Fixes #25 