### PR TITLE
Notes panel

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -39,8 +39,13 @@
     </div>
     <hr/>
     {% if post.notes and current_user.is_authenticated %}
-    <div class="post-content">
-        {{ post.notes|gfm }}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Notes</h3>
+        </div>
+        <div class="panel-body">
+            {{ post.notes|gfm }}
+        </div>
     </div>
     <hr/>
     {% endif %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -39,6 +39,7 @@
     </div>
 
     {% if post.notes and current_user.is_authenticated %}
+    <p>&nbsp;</p>
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title">Notes</h3>

--- a/templates/post.html
+++ b/templates/post.html
@@ -37,7 +37,7 @@
     <div class="post-content">
         {{ post.content|gfm }}
     </div>
-    <hr/>
+
     {% if post.notes and current_user.is_authenticated %}
     <div class="panel panel-default">
         <div class="panel-heading">
@@ -47,6 +47,7 @@
             {{ post.notes|gfm }}
         </div>
     </div>
+    {% else %}
     <hr/>
     {% endif %}
 


### PR DESCRIPTION
This PR adds a [bootstrap panel](http://getbootstrap.com/components/#panels) around a post's notes, so as to distinguish them from the content of the post.

Fixes #45 