### PR TITLE
If the user is not logged in, only count non-draft posts.

### DIFF
--- a/templates/list_tags.html
+++ b/templates/list_tags.html
@@ -27,7 +27,12 @@
     {% for tag in tags %}
         <div class="index-tag index-tag-id-{{tag.id}} index-tag-index-{{index()}} index-tag-{{odd_even()}}">
             <a href="{{ url_for('get_tag', tag_id=tag.id) }}">
-                <h1>{{ tag.name }} <small>- {{ tag.posts.count() }} posts</small></h1>
+                <h1>{{ tag.name }} <small>- {% if current_user.is_authenticated %}{{
+                                                tag.posts.count()
+                                            }}{% else %}{{
+                                                tag.posts.filter_by(is_draft=False).count()
+                                            }}{% endif %} posts</small>
+                </h1>
             </a>
             <hr/>
         </div>


### PR DESCRIPTION
This PR changes the tag list so that, if a user is not logged in, the count of posts per tag only counts non-draft posts.

Fixes #48 