### PR TITLE
Customize appearance

### DIFF
--- a/blogware.py
+++ b/blogware.py
@@ -39,6 +39,7 @@ import gfm
 import markdown
 from slugify import slugify
 import dateutil.parser
+import jinja2
 
 try:
     __revision__ = git.Repo('.').git.describe(tags=True, dirty=True,
@@ -105,6 +106,12 @@ if __name__ == "__main__":
 
 
 app = Flask(__name__)
+
+if Config.CUSTOM_TEMPLATES:
+    loader = jinja2.ChoiceLoader([
+        jinja2.FileSystemLoader(Config.CUSTOM_TEMPLATES),
+        app.jinja_loader])
+    app.jinja_loader = loader
 
 app.config['TEMPLATES_AUTO_RELOAD'] = True
 app.config["SECRET_KEY"] = Config.SECRET_KEY  # for WTF-forms and login

--- a/blogware.py
+++ b/blogware.py
@@ -54,6 +54,7 @@ class Config(object):
     DB_URI = environ.get('BLOGWARE_DB_URI', 'sqlite:////tmp/blog.db')
     SITENAME = environ.get('BLOGWARE_SITENAME', 'Site Name')
     SITEURL = environ.get('BLOGWARE_SITEURL', 'http://localhost:1177')
+    CUSTOM_TEMPLATES = environ.get('BLOGWARE_CUSTOM_TEMPLATES', None)
 
 
 if __name__ == "__main__":
@@ -70,6 +71,12 @@ if __name__ == "__main__":
                         default=Config.SITENAME, help='')
     parser.add_argument('--siteurl', type=str,
                         default=Config.SITEURL, help='')
+    parser.add_argument('--custom-templates', type=str,
+                        default=Config.CUSTOM_TEMPLATES,
+                        help="The path to a directory on the filesystem from "
+                             "which to load template files. If none is "
+                             "specified, the app's default internal template "
+                             "location will be used.")
 
     parser.add_argument('--create-secret-key', action='store_true')
     parser.add_argument('--create-db', action='store_true')
@@ -94,6 +101,7 @@ if __name__ == "__main__":
     Config.DB_URI = args.db_uri
     Config.SITENAME = args.sitename
     Config.SITEURL = args.siteurl
+    Config.CUSTOM_TEMPLATES = args.custom_templates
 
 
 app = Flask(__name__)
@@ -425,6 +433,8 @@ if __name__ == "__main__":
     print('Site url: {}'.format(Config.SITEURL))
     print('Port: {}'.format(Config.PORT))
     print('Debug: {}'.format(Config.DEBUG))
+    if Config.CUSTOM_TEMPLATES:
+        print('Custom template path: {}'.format(Config.CUSTOM_TEMPLATES))
     if Config.DEBUG:
         print('DB URI: {}'.format(Config.DB_URI))
         print('Secret Key: {}'.format(Config.SECRET_KEY))

--- a/templates/page_links.fragment.html
+++ b/templates/page_links.fragment.html
@@ -1,3 +1,21 @@
+{# blogware - a python blogging system
+   Copyright (C) 2016-2017 izrik
+
+   This file is a part of blogware.
+
+   Blogware is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Blogware is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with blogware.  If not, see <http://www.gnu.org/licenses/>.
+#}
 <nav class="paginate-container">
 <ul class="pagination">
     <li>


### PR DESCRIPTION
This PR adds a command-line arg and envvar for specifying a custom template location. If such a custom location is specified, then the app will load jinja templates from that location _first_, before falling back on the default built-in templates.

A user can override any aspect of the appearance of the site. For example, putting a file named `index.html` in the custom template folder will override the default template for the index page. Putting a file named `base.html` in the folder will override the base template for all pages. Writing a custom `index.html` that does not extend `base.html` would mean that the base template would not be loaded at all for the index.

Fixes #27 