### PR TITLE
Configurable author name

### DIFF
--- a/blogware.py
+++ b/blogware.py
@@ -273,6 +273,10 @@ class Options(object):
 
     cycle = cycle
 
+    @staticmethod
+    def get_author():
+        return Options.get('author', Config.AUTHOR)
+
 
 @login_manager.user_loader
 def load_user(user_id):

--- a/blogware.py
+++ b/blogware.py
@@ -56,6 +56,7 @@ class Config(object):
     SITENAME = environ.get('BLOGWARE_SITENAME', 'Site Name')
     SITEURL = environ.get('BLOGWARE_SITEURL', 'http://localhost:1177')
     CUSTOM_TEMPLATES = environ.get('BLOGWARE_CUSTOM_TEMPLATES', None)
+    AUTHOR = environ.get('BLOGWARE_AUTHOR', 'The Author')
 
 
 if __name__ == "__main__":
@@ -78,6 +79,10 @@ if __name__ == "__main__":
                              "which to load template files. If none is "
                              "specified, the app's default internal template "
                              "location will be used.")
+    parser.add_argument('--author', type=str, default=Config.AUTHOR,
+                        help='The name of the author of the site. This name '
+                             'will appear in the "Posted by" line on posts, '
+                             'and in the copyright section in the footer.')
 
     parser.add_argument('--create-secret-key', action='store_true')
     parser.add_argument('--create-db', action='store_true')
@@ -107,6 +112,7 @@ if __name__ == "__main__":
     Config.SITENAME = args.sitename
     Config.SITEURL = args.siteurl
     Config.CUSTOM_TEMPLATES = args.custom_templates
+    Config.AUTHOR = args.author
 
 
 app = Flask(__name__)

--- a/blogware.py
+++ b/blogware.py
@@ -280,7 +280,7 @@ class Options(object):
 
 @login_manager.user_loader
 def load_user(user_id):
-    return User("izrik", "izrik@izrik.com")
+    return User(Options.get_author(), Options.get_author())
 
 
 @app.context_processor
@@ -322,7 +322,7 @@ def login():
         flash('Password is invalid', 'error')
         return redirect(url_for('login'))
 
-    user = User("izrik", "izrik@izrik.com")
+    user = User(Options.get_author(), Options.get_author())
     login_user(user)
     flash('Logged in successfully')
     # return redirect(request.args.get('next_url') or url_for('index'))

--- a/templates/base.html
+++ b/templates/base.html
@@ -71,7 +71,7 @@
         <small><a href="/login">Login</a></small><br/>
         {% endif %}
         {% block copyright %}
-        <small>Copyright &copy; 2017 by the author.</small><br/>
+        <small>Copyright &copy; 2017 by {{ Options.get_author() }}.</small><br/>
         {% endblock %}
         <small>Powered by <a href="https://github.com/izrik/blogware">blogware</a>.</small><br/>
         <small>Revision: <code>{{ Options.get_revision() }}</code></small>

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,7 +34,7 @@
             <a href="{{ url_for('get_post', slug=post.slug) }}">
                 <h1>{{ post.title }}{% if post.is_draft%} <small>(Draft)</small>{% endif %}</h1>
             </a>
-            <p>{{ post.date.strftime('%Y-%m-%d') }} - izrik</p>
+            <p>{{ post.date.strftime('%Y-%m-%d') }} - {{ Options.get_author() }}</p>
             <blockquote>{{ post.summary if post.summary }}</blockquote>
             <hr/>
         </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -27,7 +27,7 @@
     </a>
     {% set post_date = post.date.strftime('%Y-%m-%d') %}
     {% set post_l_u_date = post.last_updated_date.strftime('%Y-%m-%d') %}
-    <p class="post-author">Posted by izrik on {{ post_date }}</p>
+    <p class="post-author">Posted by {{ Options.get_author() }} on {{ post_date }}</p>
     {% if post_date != post_l_u_date  %}
     <p class="post-date">Last updated on {{ post_l_u_date  }}</p>
     {% endif %}

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -33,7 +33,7 @@
             <a href="{{ url_for('get_post', slug=post.slug) }}">
                 <h2>{{ post.title }}{% if post.is_draft%} <small>(Draft)</small>{% endif %}</h2>
             </a>
-            <p>{{ post.date.strftime('%Y-%m-%d') }} - izrik</p>
+            <p>{{ post.date.strftime('%Y-%m-%d') }} - {{ Options.get_author() }}</p>
             <hr/>
         </div>
     {% else %}


### PR DESCRIPTION
This PR adds a configurable option (`author`), along with envvar and cli arg to set it. The option represents the name of the person operating the given site. This PR replaces hard-coded instances of "izrik".
Fixes #56 