### PR TITLE
Next/previous links

### DIFF
--- a/blogware.py
+++ b/blogware.py
@@ -338,7 +338,26 @@ def get_post(slug):
     if post.is_draft and not current_user.is_authenticated:
         raise Unauthorized()
     user = current_user
-    return render_template('post.html', config=Config, post=post, user=user)
+
+    if current_user.is_authenticated:
+        next_post = Post.query\
+            .filter(Post.date > post.date)\
+            .order_by(Post.date.asc()).limit(1).first()
+        prev_post = Post.query\
+            .filter(Post.date < post.date)\
+            .order_by(Post.date.desc()).limit(1).first()
+    else:
+        next_post = Post.query\
+            .filter_by(is_draft=False)\
+            .filter(Post.date > post.date)\
+            .order_by(Post.date.asc()).limit(1).first()
+        prev_post = Post.query\
+            .filter_by(is_draft=False)\
+            .filter(Post.date < post.date)\
+            .order_by(Post.date.desc()).limit(1).first()
+
+    return render_template('post.html', config=Config, post=post, user=user,
+                           next_post=next_post, prev_post=prev_post)
 
 
 @app.route('/edit/<slug>', methods=['GET', 'POST'])

--- a/templates/post.html
+++ b/templates/post.html
@@ -61,6 +61,20 @@
             <a href="{{ url_for('edit_post', slug=post.slug) }}">Edit</a>
         </div>
     {% endif %}
+    <nav>
+        <ul class="pager">
+            <li class="previous">
+                <a rel="prev"
+                   {% if prev_post %} href="{{ url_for('get_post', slug=prev_post.slug) }}"{% endif %}
+                    ><span aria-hidden="true">&larr;</span> Older</a>
+            </li>
+            <li class="next">
+                <a rel="next"
+                   {% if next_post %} href="{{ url_for('get_post', slug=next_post.slug) }}"{% endif %}
+                    >Newer <span aria-hidden="true">&rarr;</span></a>
+            </li>
+        </ul>
+    </nav>
 </div>
 
 {% endblock %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -63,16 +63,20 @@
     {% endif %}
     <nav>
         <ul class="pager">
+            {% if prev_post %}
             <li class="previous">
                 <a rel="prev"
                    {% if prev_post %} href="{{ url_for('get_post', slug=prev_post.slug) }}"{% endif %}
                     ><span aria-hidden="true">&larr;</span> Older</a>
             </li>
+            {% endif %}
+            {% if next_post %}
             <li class="next">
                 <a rel="next"
                    {% if next_post %} href="{{ url_for('get_post', slug=next_post.slug) }}"{% endif %}
                     >Newer <span aria-hidden="true">&rarr;</span></a>
             </li>
+            {% endif %}
         </ul>
     </nav>
 </div>


### PR DESCRIPTION
This PR adds to the post page links that point at the next (newer) and previous (older) posts, relative to the post being viewed. The logic takes care to not link to drafts when the user is not logged in.

Fixes #30 