### PR TITLE
Add configurable copyright string

### DIFF
--- a/plantagenet.py
+++ b/plantagenet.py
@@ -87,6 +87,7 @@ class Config(object):
     SITEURL = environ.get('PLANTAGENET_SITEURL', 'http://localhost:1177')
     CUSTOM_TEMPLATES = environ.get('PLANTAGENET_CUSTOM_TEMPLATES', None)
     AUTHOR = environ.get('PLANTAGENET_AUTHOR', 'The Author')
+    COPYRIGHT = environ.get('PLANTAGENET_COPYRIGHT', '')
     LOCAL_RESOURCES = environ.get('PLANTAGENET_LOCAL_RESOURCES', False)
     EXTERN_ROOT = environ.get('PLANTAGENET_EXTERN_ROOT', None)
     EXTRA_LINKS = environ.get('PLANTAGENET_EXTRA_LINKS', '')
@@ -122,6 +123,10 @@ if __name__ == "__main__":
                         help='The name of the author of the site. This name '
                              'will appear in the "Posted by" line on posts, '
                              'and in the copyright section in the footer.')
+    parser.add_argument('--copyright', type=str, default=Config.COPYRIGHT,
+                        help='Copyright date string shown in the footer, '
+                             'e.g. "2012 - 2026". Overrides the default which '
+                             'uses the author name and current year.')
     parser.add_argument('--local-resources', action='store_true',
                         default=Config.LOCAL_RESOURCES,
                         help='Use local resources (CSS and JS served from the '
@@ -169,6 +174,7 @@ if __name__ == "__main__":
     Config.SITEURL = args.siteurl
     Config.CUSTOM_TEMPLATES = args.custom_templates
     Config.AUTHOR = args.author
+    Config.COPYRIGHT = args.copyright
     Config.LOCAL_RESOURCES = args.local_resources
     Config.EXTERN_ROOT = args.extern_root
     Config.EXTRA_LINKS = args.extra_links
@@ -493,6 +499,10 @@ class Options(object):
         return Options.get('author', Config.AUTHOR)
 
     @staticmethod
+    def get_copyright():
+        return Options.get('copyright', Config.COPYRIGHT)
+
+    @staticmethod
     def should_use_local_resources():
         return Config.LOCAL_RESOURCES
 
@@ -718,6 +728,8 @@ def admin():
     if request.method == 'GET':
         return render_template('admin.html',
                                sitename=Options.get_sitename(),
+                               copyright=Options.get_copyright(),
+                               current_year=str(datetime.now().year),
                                extra_links=Options.get('extra_links', ''))
 
     sitename = request.form.get('sitename', '').strip()
@@ -728,6 +740,9 @@ def admin():
     if new_password:
         hashed = bcrypt.generate_password_hash(new_password).decode('utf-8')
         Options.set('hashed_password', hashed)
+
+    copyright = request.form.get('copyright', '').strip()
+    Options.set('copyright', copyright)
 
     extra_links = request.form.get('extra_links', '').strip()
     Options.set('extra_links', extra_links)

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -13,6 +13,17 @@
                            name="sitename" value="{{ sitename }}" /></td>
             </tr>
             <tr>
+                <td><label for="copyright">Copyright</label></td>
+                <td>
+                    <input class="form-control" type="text" id="copyright"
+                           name="copyright" value="{{ copyright }}" />
+                    {% if copyright and current_year not in copyright %}
+                    <p class="help-block text-danger">Warning: {{ current_year }} is not in the copyright date. You may need to update it.</p>
+                    {% endif %}
+                    <p class="help-block">Copyright date string shown in the footer, e.g. <code>2012 - 2026</code>.</p>
+                </td>
+            </tr>
+            <tr>
                 <td><label for="extra_links">Extra Links</label></td>
                 <td>
                     <input class="form-control" type="text" id="extra_links"

--- a/templates/base.html
+++ b/templates/base.html
@@ -109,7 +109,11 @@
         <small><a href="/login">Login</a></small><br/>
         {% endif %}
         {% block copyright %}
-        <small>Copyright &copy; 2017 by {{ Options.get_author() }}.</small><br/>
+        {% if Options.get_copyright() %}
+        <small>Copyright &copy; {{ Options.get_copyright() }}.</small><br/>
+        {% else %}
+        <small>Copyright &copy; {{ Options.get_author() }}.</small><br/>
+        {% endif %}
         {% endblock %}
         <small>Powered by <a href="https://github.com/izrik/plantagenet">plantagenet</a>.</small><br/>
         <small>Version: <code>{{ Options.get_version() }}</code></small><br/>

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -88,3 +88,54 @@ def test_admin_post_clears_extra_links_when_empty(cl, login):
                             'extra_links': ''})
 
     assert plantagenet.Options.get('extra_links') == ''
+
+
+def test_admin_shows_current_copyright(cl, login):
+    app.db.session.add(plantagenet.Option('copyright', '2012 - 2026'))
+    app.db.session.commit()
+
+    login()
+    response = cl.get('/admin')
+    assert b'2012 - 2026' in response.data
+
+
+def test_admin_post_updates_copyright(cl, login):
+    login()
+    cl.post('/admin', data={'sitename': '', 'new_password': '',
+                            'extra_links': '', 'copyright': '2012 - 2026'})
+
+    assert plantagenet.Options.get('copyright') == '2012 - 2026'
+
+
+def test_admin_shows_copyright_warning_when_year_missing(cl, login):
+    from datetime import datetime
+    current_year = str(datetime.now().year)
+    old_year = str(int(current_year) - 1)
+
+    app.db.session.add(plantagenet.Option('copyright', f'2012 - {old_year}'))
+    app.db.session.commit()
+
+    login()
+    response = cl.get('/admin')
+    assert b'Warning' in response.data
+
+
+def test_admin_no_copyright_warning_when_year_present(cl, login):
+    from datetime import datetime
+    current_year = str(datetime.now().year)
+
+    app.db.session.add(
+        plantagenet.Option('copyright', f'2012 - {current_year}'))
+    app.db.session.commit()
+
+    login()
+    response = cl.get('/admin')
+    assert b'Warning' not in response.data
+
+
+def test_footer_shows_copyright_string(cl):
+    app.db.session.add(plantagenet.Option('copyright', '2012 - 2026'))
+    app.db.session.commit()
+
+    response = cl.get('/')
+    assert b'2012 - 2026' in response.data


### PR DESCRIPTION
## Summary

- Adds a `PLANTAGENET_COPYRIGHT` env var and `--copyright` CLI arg for setting a custom footer copyright string
- Admin panel now has a copyright field with a warning if the current year is missing from the value
- Footer falls back to the author name if no copyright string is configured

## Test plan

- [ ] Visit `/admin`, set a copyright string, verify it appears in the footer
- [ ] Set a copyright string missing the current year, verify warning appears in admin
- [ ] Leave copyright blank, verify footer falls back to author name
- [ ] All 15 admin tests pass (`PYTHONPATH=. .venv/bin/pytest tests/admin.py -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)